### PR TITLE
Paso de funciones a menús corresponientes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,7 @@ void initWifiConnection(char*, char*);
 // ## Access Point
 void ap_start(char*, char*); // Inicializa SoftAP (IP/gateway/máscara + SSID/clave)
 IPAddress ap_ip(void); // Devuelve la IP actual del AP (sin guardar global)
-void initiAP();
+void initiAP(char*, char*);
 
 // ## Portal cautivo
 void handleRoot();


### PR DESCRIPTION
 Las funciones de conectarse a WiFi, iniciar el Access Point fueron pasados al selector dentro de `loop()`. **Falta que el usuario pueda introducir el SSID y contraseña directamente en la terminal de Bluetooth.**

Ya probé con el ESP-32, el resto de las funciones funcionan apropiadamente.